### PR TITLE
Initial incomplete recursive-zone-timing changes

### DIFF
--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -14,6 +14,16 @@
 #include "../common/TracyForceInline.hpp"
 #include "../common/TracyQueue.hpp"
 
+#define TRACY_ACCUMULATE_NON_REENTRANT_TOTAL_ZONE_TIME_ONLY
+
+constexpr bool AccumulateNonReentrantTotalZoneTimeOnly =
+#ifdef TRACY_ACCUMULATE_NON_REENTRANT_TOTAL_ZONE_TIME_ONLY
+    true
+#else // TRACY_ACCUMULATE_NON_REENTRANT_TOTAL_ZONE_TIME_ONLY
+    false
+#endif // TRACY_ACCUMULATE_NON_REENTRANT_TOTAL_ZONE_TIME_ONLY
+    ;
+
 namespace tracy
 {
 

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -11785,7 +11785,10 @@ void View::DrawStatistics()
                             if( start >= min && end <= max )
                             {
                                 const auto zt = end - start;
-                                total += zt;
+                                if (!AccumulateNonReentrantTotalZoneTimeOnly || !IsZoneReentry(z))
+                                {
+                                    total += zt;
+                                }
                                 if( m_statSelf ) selfTotal += zt - GetZoneChildTimeFast( z );
                                 cnt++;
                             }
@@ -11814,7 +11817,10 @@ void View::DrawStatistics()
                                 if( start >= min && end <= max )
                                 {
                                     const auto zt = end - start;
-                                    total += zt;
+                                    if (!AccumulateNonReentrantTotalZoneTimeOnly || !IsZoneReentry(z))
+                                    {
+                                        total += zt;
+                                    }
                                     if( m_statSelf ) selfTotal += zt - GetZoneChildTimeFast( z );
                                     cnt++;
                                 }
@@ -16686,6 +16692,16 @@ const ZoneEvent* View::GetZoneParent( const ZoneEvent& zone, uint64_t tid ) cons
         }
     }
     return nullptr;
+}
+
+bool View::IsZoneReentry( const ZoneEvent& zone ) const
+{
+    return m_worker.IsZoneReentry( zone );
+}
+
+bool View::IsZoneReentry( const ZoneEvent& zone, uint64_t tid ) const
+{
+    return m_worker.IsZoneReentry ( zone, tid );
 }
 
 const GpuEvent* View::GetZoneParent( const GpuEvent& zone ) const

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -236,6 +236,8 @@ private:
     int GetZoneDepth( const ZoneEvent& zone, uint64_t tid ) const;
     const ZoneEvent* GetZoneParent( const ZoneEvent& zone ) const;
     const ZoneEvent* GetZoneParent( const ZoneEvent& zone, uint64_t tid ) const;
+    bool IsZoneReentry( const ZoneEvent& zone ) const;
+    bool IsZoneReentry( const ZoneEvent& zone, uint64_t tid ) const;
     const GpuEvent* GetZoneParent( const GpuEvent& zone ) const;
     const ThreadData* GetZoneThreadData( const ZoneEvent& zone ) const;
     uint64_t GetZoneThread( const ZoneEvent& zone ) const;

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -540,6 +540,9 @@ public:
     tracy_force_inline const GhostKey& GetGhostFrame( const Int24& frame ) const { return m_data.ghostFrames[frame.Val()]; }
 #endif
 
+    bool IsZoneReentry( const ZoneEvent& zone ) const;
+    bool IsZoneReentry( const ZoneEvent& zone, uint64_t tid ) const;
+
     tracy_force_inline const bool HasZoneExtra( const ZoneEvent& ev ) const { return ev.extra != 0; }
     tracy_force_inline const ZoneExtra& GetZoneExtra( const ZoneEvent& ev ) const { return m_data.zoneExtra[ev.extra]; }
 


### PR DESCRIPTION
This draft pull request is only for discussion -- the changes are massively incomplete; I'm just making a PR to share code.

Many things are missing:

- It's very lightly tested -- I've only tried it on the test case I wrote at https://github.com/rokopt/stellar-core/commit/494e97f090ff02fe49e1fe79d248de719d023e7d .
- I'm not certain that `SrcLoc()` is really a unique zone identifier.  It is in the test case I wrote, but that only has two zones!
- I've only changed the time tracking so far, not the count tracking.  I have created a `bool` that indicates whether a zone-end event is for a re-entered zone, but I haven't yet made use of it in the code paths that count the number of zone events.
- I'm not sure that performance will be adequate:  it does a linear search of the zone stack in the worker thread each time it receives a zone-end event.  If this is too slow, we might need some new data structure, or other approach altogether.
- I haven't created the tri-state that the maintainer will require yet -- I'm just replacing the behavior with "Self time" unchecked.
- I've only changed the GUI in one place; there are many other places where the time is displayed (for example, there are different cases depending on whether a filter is active, or whether a range has been specified, and I've only changed the summary-statistics panel, not the find-zone display).