### PR TITLE
Add dependabot.yml for "github-actions" version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "02:00"
+    open-pull-requests-limit: 2
+    groups:
+      all-actions:
+        applies-to: version-updates
+        patterns: [ "*" ]


### PR DESCRIPTION
### What

Adding `dependabot.yml` to enable [dependency version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) for "github-actions" through Dependabot. This config sets "github-actions" version updates to run on a `weekly` schedule, and sets max PRs that Dependabot can create for version updates  per package-ecosystem. 

### Why

To enable using the latest "github-actions" versions.

### Known limitations

N/A
